### PR TITLE
Fix incorrect artifact in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ repositories {
 
 dependencies {
     // Replace modImplementation with modApi if you expose components in your own API
-    modImplementation "com.github.NerdHubMC:Cardinal-Components-API:<VERSION>"
+    modImplementation "com.github.NerdHubMC.Cardinal-Components-API:MODULE>:<VERSION>"
     // Includes Cardinal Components API as a Jar-in-Jar dependency (optional)
-    include "com.github.NerdHubMC:Cardinal-Components-API:<VERSION>"
+    include "com.github.NerdHubMC.Cardinal-Components-API:<MODULE>:<VERSION>"
 }
 ```
 


### PR DESCRIPTION
The cardinals component readme shows an inaccurate artifact, throwing an error whenever someone attempts to add it to a project.