### PR TITLE
Add mixined fallback for binary compatibility with beta 1

### DIFF
--- a/cardinal-components-base/src/main/java/org/ladysnake/cca/mixin/base/ComponentMixin.java
+++ b/cardinal-components-base/src/main/java/org/ladysnake/cca/mixin/base/ComponentMixin.java
@@ -1,0 +1,56 @@
+/*
+ * Cardinal-Components-API
+ * Copyright (C) 2019-2024 Ladysnake
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package org.ladysnake.cca.mixin.base;
+
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.registry.RegistryWrapper;
+import org.ladysnake.cca.api.v3.component.Component;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Unique;
+
+@Mixin(Component.class)
+public interface ComponentMixin {
+    @Unique
+    void readFromNbt(NbtCompound tag);
+    @Unique
+    void writeToNbt(NbtCompound tag);
+
+    /**
+     * @author Pyrofab
+     * @reason binary compatibility with mods released for beta.1
+     */
+    @Overwrite
+    default void readFromNbt(NbtCompound tag, RegistryWrapper.WrapperLookup registryLookup) {
+        readFromNbt(tag);
+    }
+
+    /**
+     * @author Pyrofab
+     * @reason binary compatibility with mods released for beta.1
+     */
+    @Overwrite
+    default void writeToNbt(NbtCompound tag, RegistryWrapper.WrapperLookup registryLookup) {
+        writeToNbt(tag);
+    }
+}

--- a/cardinal-components-base/src/main/resources/fabric.mod.json
+++ b/cardinal-components-base/src/main/resources/fabric.mod.json
@@ -48,5 +48,11 @@
     "issues": "https://github.com/Ladysnake/Cardinal-Components-API/issues",
     "sources": "https://github.com/Ladysnake/Cardinal-Components-API"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "mixins": [
+    {
+      "environment": "*",
+      "config": "mixins.cardinal_components_base.json"
+    }
+  ]
 }

--- a/cardinal-components-base/src/main/resources/mixins.cardinal_components_base.json
+++ b/cardinal-components-base/src/main/resources/mixins.cardinal_components_base.json
@@ -1,0 +1,14 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "compatibilityLevel": "JAVA_8",
+  "package": "org.ladysnake.cca.mixin.base",
+  "mixins": [
+    "ComponentMixin"
+  ],
+  "client": [
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}


### PR DESCRIPTION
The addition of a new parameter to component serialization methods caused binary incompatibilities within a single minecraft version, which is rather unfortunate. This is an attempt at fixing this incompatibility in the most simple of cases.

Note that this PR only seeks to address binary incompatibility - source compatibility will still have to be addressed by dependencies.