### PR TITLE
Add Immersive Portals compatibility for the block provider

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,6 +49,14 @@ allprojects {
             name = "JitPack"
             url = URI("https://jitpack.io")
         }
+        maven {
+            name = "Modrinth"
+            url = URI("https://api.modrinth.com/maven")
+        }
+        maven {
+            name = "Shedaniel"
+            url = URI("https://maven.shedaniel.me")
+        }
     }
 
     dependencies {

--- a/cardinal-components-block/build.gradle
+++ b/cardinal-components-block/build.gradle
@@ -4,4 +4,5 @@ dependencies {
     annotationProcessor api(project(path: ":cardinal-components-base", configuration: "namedElements"))
     modApi fabricApi.module("fabric-api-lookup-api-v1", rootProject.fabric_api_version)
     testmodImplementation project(":cardinal-components-base").sourceSets.testmod.output
+    modCompileOnly "com.github.iPortalTeam:ImmersivePortalsMod:${rootProject.immersive_portals_version}"
 }

--- a/cardinal-components-block/src/main/java/org/ladysnake/cca/internal/BlockEntityAddress.java
+++ b/cardinal-components-block/src/main/java/org/ladysnake/cca/internal/BlockEntityAddress.java
@@ -27,16 +27,21 @@ import net.minecraft.network.RegistryByteBuf;
 import net.minecraft.network.codec.PacketCodec;
 import net.minecraft.network.codec.PacketCodecs;
 import net.minecraft.registry.Registries;
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.RegistryKeys;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
 
 public record BlockEntityAddress(
     BlockEntityType<?> beType,
-    BlockPos bePos
+    BlockPos bePos,
+    RegistryKey<World> worldKey
 ) {
 
     public static final PacketCodec<RegistryByteBuf, BlockEntityAddress> CODEC = PacketCodec.tuple(
         PacketCodecs.entryOf(Registries.BLOCK_ENTITY_TYPE), BlockEntityAddress::beType,
         BlockPos.PACKET_CODEC, BlockEntityAddress::bePos,
+        RegistryKey.createPacketCodec(RegistryKeys.WORLD), BlockEntityAddress::worldKey,
         BlockEntityAddress::new
     );
 }

--- a/cardinal-components-block/src/main/java/org/ladysnake/cca/mixin/block/common/MixinBlockEntity.java
+++ b/cardinal-components-block/src/main/java/org/ladysnake/cca/mixin/block/common/MixinBlockEntity.java
@@ -102,9 +102,14 @@ public abstract class MixinBlockEntity implements ComponentProvider {
 
     @Override
     public <C extends AutoSyncedComponent> ComponentUpdatePayload<?> toComponentPacket(ComponentKey<? super C> key, boolean required, RegistryByteBuf data) {
+        World world = this.getWorld();
+        if (world == null) {
+            return null;
+        }
+
         return new ComponentUpdatePayload<>(
             CardinalComponentsBlock.PACKET_ID,
-            new BlockEntityAddress(this.getType(), this.getPos()),
+            new BlockEntityAddress(this.getType(), this.getPos(), world.getRegistryKey()),
             required,
             key.getId(),
             data

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,8 @@ fabric_api_version=0.106.1+1.21.3
 
 elmendorf_version=0.13.0
 
+immersive_portals_version=v6.0.3-mc1.21.1
+
 #Publishing
 mod_version = 6.2.0
 curseforge_id = 318449


### PR DESCRIPTION
Adds Immersive Portals compatibility for the block provider. To support this, an optional dependency on IP has been added.
Note that IP only has a few preview releases for 1.21.1, so this change can't be observed with the newer versions yet.